### PR TITLE
Support SIT native_properties in merge

### DIFF
--- a/datasources/sources/geojson.rb
+++ b/datasources/sources/geojson.rb
@@ -59,7 +59,7 @@ class GeoJsonSource < Source
     feat['properties']['tags']
   end
 
-  def map_native_properties(feat, properties)
+  def map_native_properties(feat, _properties)
     feat['properties']['natives']
   end
 end

--- a/datasources/sources/geojson.rb
+++ b/datasources/sources/geojson.rb
@@ -58,4 +58,8 @@ class GeoJsonSource < Source
   def map_tags(feat)
     feat['properties']['tags']
   end
+
+  def map_native_properties(feat, properties)
+    feat['properties']['natives']
+  end
 end


### PR DESCRIPTION
The mapping of native_properties was missing in GeoJsonSource, we arrive here https://github.com/teritorio/elasa-datasources/blob/4e8165f8ebdd02d192bfb62e8770cb97f56c71dd/datasources/transforms/join.rb#L54 without row[:properties][:natives], I fix it with this commit